### PR TITLE
🧹 chore: remove unused import SerdeSerError in yaml_ser.rs

### DIFF
--- a/crates/recoco-utils/src/yaml_ser.rs
+++ b/crates/recoco-utils/src/yaml_ser.rs
@@ -386,7 +386,6 @@ impl ser::SerializeTupleVariant for VariantSeqSerializer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde::ser::Error as SerdeSerError;
     use serde::{Serialize, Serializer};
     use std::collections::BTreeMap;
     use yaml_rust2::yaml::{Hash, Yaml};


### PR DESCRIPTION
This change removes an unused import `SerdeSerError` in `crates/recoco-utils/src/yaml_ser.rs`. Removing unused imports helps keep the codebase clean and maintainable. The removal was verified by manual inspection and `grep` to ensure no other code depended on this alias. Although `cargo check` and `cargo test` encountered network timeouts when updating the index, the change is trivial and safe.

---
*PR created automatically by Jules for task [11877652313253078393](https://jules.google.com/task/11877652313253078393) started by @bashandbone*