### PR TITLE
🧪 test: add unit tests for sanitize_identifier in db.rs

### DIFF
--- a/crates/recoco-utils/src/db.rs
+++ b/crates/recoco-utils/src/db.rs
@@ -26,3 +26,41 @@ pub fn sanitize_identifier(s: &str) -> String {
     }
     result
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_identifier_empty() {
+        assert_eq!(sanitize_identifier(""), "");
+    }
+
+    #[test]
+    fn test_sanitize_identifier_alphanumeric() {
+        assert_eq!(sanitize_identifier("HelloWorld123"), "HelloWorld123");
+    }
+
+    #[test]
+    fn test_sanitize_identifier_underscores() {
+        assert_eq!(sanitize_identifier("hello_world_123"), "hello_world_123");
+    }
+
+    #[test]
+    fn test_sanitize_identifier_non_alphanumeric() {
+        assert_eq!(sanitize_identifier("hello-world.123"), "hello__world__123");
+    }
+
+    #[test]
+    fn test_sanitize_identifier_only_non_alphanumeric() {
+        assert_eq!(sanitize_identifier("!@#"), "______");
+    }
+
+    #[test]
+    fn test_sanitize_identifier_unicode() {
+        // '🚀' is not alphanumeric, should be replaced by "__"
+        assert_eq!(sanitize_identifier("hello🚀"), "hello__");
+        // 'ö' is alphanumeric according to rust's char::is_alphanumeric
+        assert_eq!(sanitize_identifier("helloö"), "helloö");
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds missing unit tests for the deterministic string manipulation function `sanitize_identifier` in `crates/recoco-utils/src/db.rs`. 

📊 **Coverage:** What scenarios are now tested
The new tests cover the following scenarios:
- Empty strings (`""` -> `""`)
- Strings with only alphanumeric characters (`"HelloWorld123"` -> `"HelloWorld123"`)
- Strings with underscores (`"hello_world_123"` -> `"hello_world_123"`)
- Strings with non-alphanumeric characters (`"hello-world.123"` -> `"hello__world__123"`)
- Strings with only non-alphanumeric characters (`"!@#"` -> `"______"`)
- Strings with unicode characters (`"hello🚀"` -> `"hello__"`, `"helloö"` -> `"helloö"`)

✨ **Result:** The improvement in test coverage
The `sanitize_identifier` function is now fully tested, ensuring that its behavior remains deterministic and correct, preventing future regressions.

---
*PR created automatically by Jules for task [9624714244261278877](https://jules.google.com/task/9624714244261278877) started by @bashandbone*