### PR TITLE
🧪 Add test for `RefList::headn` in `immutable.rs`

### DIFF
--- a/crates/recoco-utils/src/immutable.rs
+++ b/crates/recoco-utils/src/immutable.rs
@@ -80,3 +80,26 @@ impl<'a, T> Iterator for &'a RefList<'a, T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_headn() {
+        let nil: RefList<'_, i32> = RefList::Nil;
+        assert_eq!(nil.headn(0), None);
+        assert_eq!(nil.headn(1), None);
+
+        let n3 = nil.prepend(3);
+        let n2 = n3.prepend(2);
+        let n1 = n2.prepend(1);
+
+        // List is 1 -> 2 -> 3 -> Nil
+        assert_eq!(n1.headn(0), Some(&1));
+        assert_eq!(n1.headn(1), Some(&2));
+        assert_eq!(n1.headn(2), Some(&3));
+        assert_eq!(n1.headn(3), None);
+        assert_eq!(n1.headn(10), None);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
There were no explicit unit tests for the `RefList::headn` method in `immutable.rs`.

📊 **Coverage:** What scenarios are now tested
- Calling `headn` on an empty `Nil` list returns `None`.
- Calling `headn(0)`, `headn(1)`, and `headn(2)` on a list of length 3 correctly retrieves the first, second, and third elements.
- Calling `headn(3)` and out-of-bounds `headn(10)` on a list of length 3 safely returns `None`.

✨ **Result:** The improvement in test coverage
`RefList::headn` behavior is thoroughly verified across nominal and edge cases, ensuring recursive traversal works accurately and preventing future regressions in list item retrieval.

---
*PR created automatically by Jules for task [16629088503693405213](https://jules.google.com/task/16629088503693405213) started by @bashandbone*