### PR TITLE
fix: ensure execution plan initialized after target setup (#49)

### DIFF
--- a/crates/recoco-core/src/builder/exec_ctx.rs
+++ b/crates/recoco-core/src/builder/exec_ctx.rs
@@ -23,6 +23,7 @@ pub struct ImportOpExecutionContext {
     pub source_id: i32,
 }
 
+#[derive(Debug, Clone)]
 pub struct ExportOpExecutionContext {
     pub target_id: i32,
     pub schema_version_id: usize,

--- a/crates/recoco-core/src/execution/db_tracking_setup.rs
+++ b/crates/recoco-core/src/execution/db_tracking_setup.rs
@@ -10,9 +10,11 @@
 // Both the upstream CocoIndex code and the Recoco modifications are licensed under the Apache-2.0 License.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::builder::exec_ctx::ExportOpExecutionContext;
 use crate::prelude::*;
 
 use crate::setup::{CombinedState, ResourceSetupChange, ResourceSetupInfo, SetupChangeType};
+use recoco_utils::error::SharedError;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 
@@ -105,7 +107,6 @@ pub struct TrackingTableSetupState {
     pub has_fast_fingerprint_column: bool,
 }
 
-#[derive(Debug)]
 pub struct TrackingTableSetupChange {
     pub desired_state: Option<TrackingTableSetupState>,
 
@@ -117,7 +118,42 @@ pub struct TrackingTableSetupChange {
 
     pub source_names_need_state_cleanup: BTreeMap<i32, BTreeSet<String>>,
 
+    /// Lazily resolved execution plan (awaited only when cleanup needs export contexts)
+    pub execution_plan:
+        Shared<BoxFuture<'static, std::result::Result<Arc<plan::ExecutionPlan>, SharedError>>>,
+    pub export_op_execution_contexts: Vec<ExportOpExecutionContext>,
+
     has_state_change: bool,
+}
+
+impl std::fmt::Debug for TrackingTableSetupChange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TrackingTableSetupChange")
+            .field("desired_state", &self.desired_state)
+            .field("min_existing_version_id", &self.min_existing_version_id)
+            .field(
+                "legacy_tracking_table_names",
+                &self.legacy_tracking_table_names,
+            )
+            .field(
+                "source_state_table_always_exists",
+                &self.source_state_table_always_exists,
+            )
+            .field(
+                "legacy_source_state_table_names",
+                &self.legacy_source_state_table_names,
+            )
+            .field(
+                "source_names_need_state_cleanup",
+                &self.source_names_need_state_cleanup,
+            )
+            .field(
+                "export_op_execution_contexts",
+                &self.export_op_execution_contexts,
+            )
+            .field("has_state_change", &self.has_state_change)
+            .finish_non_exhaustive()
+    }
 }
 
 impl TrackingTableSetupChange {
@@ -125,6 +161,10 @@ impl TrackingTableSetupChange {
         desired: Option<&TrackingTableSetupState>,
         existing: &CombinedState<TrackingTableSetupState>,
         source_names_need_state_cleanup: BTreeMap<i32, BTreeSet<String>>,
+        execution_plan: Shared<
+            BoxFuture<'static, std::result::Result<Arc<plan::ExecutionPlan>, SharedError>>,
+        >,
+        export_op_execution_contexts: Vec<ExportOpExecutionContext>,
     ) -> Option<Self> {
         let legacy_tracking_table_names = existing
             .legacy_values(desired, |v| &v.table_name)
@@ -151,6 +191,8 @@ impl TrackingTableSetupChange {
                 legacy_source_state_table_names,
                 min_existing_version_id,
                 source_names_need_state_cleanup,
+                execution_plan,
+                export_op_execution_contexts,
                 has_state_change: existing.has_state_diff(desired, |v| v),
             })
         } else {

--- a/crates/recoco-core/src/lib_context.rs
+++ b/crates/recoco-core/src/lib_context.rs
@@ -60,6 +60,8 @@ async fn build_setup_context(
         Some(&setup_execution_context.setup_state),
         existing_flow_ss,
         &analyzed_flow.flow_instance_ctx,
+        analyzed_flow.execution_plan.clone(),
+        setup_execution_context.export_ops.clone(),
     )
     .await?;
 

--- a/crates/recoco-core/src/setup/driver.rs
+++ b/crates/recoco-core/src/setup/driver.rs
@@ -353,6 +353,13 @@ pub async fn diff_flow_setup_states(
     desired_state: Option<&FlowSetupState<DesiredMode>>,
     existing_state: Option<&FlowSetupState<ExistingMode>>,
     flow_instance_ctx: &Arc<FlowInstanceContext>,
+    execution_plan: Shared<
+        BoxFuture<
+            'static,
+            std::result::Result<Arc<plan::ExecutionPlan>, recoco_utils::error::SharedError>,
+        >,
+    >,
+    export_op_execution_contexts: Vec<exec_ctx::ExportOpExecutionContext>,
 ) -> Result<FlowSetupChange> {
     let metadata_change = diff_state(
         existing_state.map(|e| &e.metadata),
@@ -415,6 +422,8 @@ pub async fn diff_flow_setup_states(
             .map(|e| Cow::Borrowed(&e.tracking_table))
             .unwrap_or_default(),
         source_names_needs_states_cleanup,
+        execution_plan,
+        export_op_execution_contexts,
     );
 
     let mut target_resources = Vec::new();
@@ -635,16 +644,6 @@ async fn apply_changes_for_flow(
     )
     .await?;
 
-    if let Some(tracking_table) = &flow_setup_change.tracking_table {
-        maybe_update_resource_setup(
-            "tracking table",
-            write,
-            std::iter::once(tracking_table),
-            |setup_change| setup_change[0].setup_change.apply_change(),
-        )
-        .await?;
-    }
-
     let mut setup_change_by_target_kind = IndexMap::<&str, Vec<_>>::new();
     for target_resource in &flow_setup_change.target_resources {
         setup_change_by_target_kind
@@ -708,6 +707,16 @@ async fn apply_changes_for_flow(
 
                    Ok::<(), Error>(())
                 },
+        )
+        .await?;
+    }
+    // Apply tracking table change after target changes, since it may need to clean up tracking states based on the target info.
+    if let Some(tracking_table) = &flow_setup_change.tracking_table {
+        maybe_update_resource_setup(
+            "tracking table",
+            write,
+            std::iter::once(tracking_table),
+            |setup_change| setup_change[0].setup_change.apply_change(),
         )
         .await?;
     }
@@ -910,8 +919,14 @@ async fn get_flow_setup_change<'a>(
         FlowSetupChangeAction::Drop => {
             let existing_state = setup_ctx.all_setup_states.flows.get(flow_ctx.flow_name());
             buffer.insert(
-                diff_flow_setup_states(None, existing_state, &flow_ctx.flow.flow_instance_ctx)
-                    .await?,
+                diff_flow_setup_states(
+                    None,
+                    existing_state,
+                    &flow_ctx.flow.flow_instance_ctx,
+                    flow_ctx.flow.execution_plan.clone(),
+                    vec![],
+                )
+                .await?,
             )
         }
     };


### PR DESCRIPTION
Adopt upstream bug fix from cocoindex-io/cocoindex#1715 (commit ba2fc4a).

The bug allowed the execution plan to be initialized before target setup was complete in certain cases. This race could cause the planner to use outdated or incomplete state, leading to subtle bugs when resources are quickly provisioned or flows reconfigured.

Changes:
- Add Debug and Clone derives to ExportOpExecutionContext
- Refactor TrackingTableSetupChange to store lazy execution plan
- Pass execution_plan and export_op_execution_contexts to diff_flow_setup_states
- Move tracking table setup to occur AFTER all target setup completes

This ensures tracking table initialization only happens after all target contexts exist, preventing race conditions in flow setup.

Closes #49